### PR TITLE
Add Time to read data to blogs

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -57,7 +57,7 @@ const { title } = Astro.props;
 		--light-bg: #ffffff;
 		--blue: #4682b4;
 		--green: #6ce385;
-		--buttons: #4c5d88;
+		--buttons: #2A9241;
 		--accent-blue: #7796cb;
 		--yellow: #ffeed6;
 	}
@@ -128,7 +128,7 @@ const { title } = Astro.props;
 	}
 
 	.link-button:hover {
-		background: #35415f;
+		background: rgba(42, 146, 65, 0.85);
 	}
 
 	main {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -180,6 +180,13 @@ const { title } = Astro.props;
 		opacity: 0.5;
 	}
 
+	.blog-info {
+		color: #4C5D88;
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: 2rem;
+	}
+
 	@media screen and (max-width: 600px) {
 		nav {
 			justify-content: center;

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -10,6 +10,8 @@ async function getDate() {
 	return new Date().toLocaleString();
 }
 const date = await getDate();
+// Get month and day from date
+const [month, day] = new Date(date).toLocaleDateString('en-US', { month: 'long', day: 'numeric' }).split(' ');
 
 if (
 	markdown === undefined ||
@@ -21,9 +23,24 @@ if (
 }
 
 let renderContent = `${markdown.replace(/\\n/g, "\n")}`;
+
+// Calculate reading time for markdown
+// Remove headings & inline Markdown formatting (bold, italic, etc.)
+const plainTextWithoutFormatting =  markdown.replace(/^#+\s+(.*)$/gm, '').replace(/(\*|_){1,2}(\S+)\1{1,2}|`{1,2}(\S+)`{1,2}/g, '$2$3');
+
+// Count the number of words in the plain text
+const wordCount = plainTextWithoutFormatting.trim().split(/\s+/).length;
+
+// Calculate the reading time in minutes (Assuming average reading speed of 200 words per minute)
+const readingTime = Math.ceil(wordCount / 200);
 ---
 
 <Layout title="Contenda Blog Preview!">
+	<div class="blog-info">
+		<span>{month} {day}</span>
+		<span>{readingTime} min read</span>
+	</div>
+	
 	<div class="blog">
 		<Markdown
 			content={renderContent}


### PR DESCRIPTION
In this PR:
- create locally maintained function to calculate approximate read time of passed markdown
- display above blog title aligned to right

Testing:
- Time is ~accurate for blogs with different amounts of code/images/text